### PR TITLE
display Monday as first weekday if locale requires it

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -32,13 +32,29 @@ module.exports = React.createClass({
     var d2 = m.clone().date(1).day();
     var d3 = m.clone().endOf('month').date();
 
-    var days = [].concat(
-      range(d1-d2+1, d1+1),
-      range(1, d3+1),
-      range(1, 42-d3-d2+1)
-    );
+    // get short names for weekdays in current locale, example:
+    //   ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+    var weeks = moment.weekdaysShort();
 
-    var weeks = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    // check if week starts with Monday
+    if (moment.localeData().firstDayOfWeek() == 1) {
+      // swap sunday with monday (weekday names)
+      weeks.push(weeks.shift());
+
+      if (d2 == 0)
+        d2 = 7; // convert to ISO day of the week (1..7)
+      var days = [].concat(
+        range(d1-d2+2, d1+1),
+        range(1, d3+1),
+        range(1, 42-d3-d2+2)
+      );
+    } else {
+      var days = [].concat(
+        range(d1-d2+1, d1+1),
+        range(1, d3+1),
+        range(1, 42-d3-d2+1)
+      );
+    }
 
     return (
       <div className={cx('m-calendar', this.props.className)}>


### PR DESCRIPTION
Get short weekday names from moment locale & use Monday instead of Sunday as first day if moment locale says so.
