### PR TITLE
Allow setting the initial view

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ http://wangzuo.github.io/input-moment
   moment={this.state.moment}
   onChange={this.handleChange}
   onSave={this.handleSave}
+  initialTab="date" {/* optional, "date" or "time" */}
 />
 ```
 Check [app.js](https://github.com/wangzuo/input-moment/blob/master/example/app.js) for a working example.

--- a/src/input-moment.js
+++ b/src/input-moment.js
@@ -9,12 +9,13 @@ module.exports = React.createClass({
 
   getInitialState() {
     return {
-      tab: 0
+      tab: this.props.initialTab
     };
   },
 
   getDefaultProps() {
     return {
+      initialTab: 'date',
       prevMonthIcon: 'ion-ios-arrow-left',
       nextMonthIcon: 'ion-ios-arrow-right'
     };
@@ -27,24 +28,24 @@ module.exports = React.createClass({
     return (
       <div className="m-input-moment">
         <div className="options">
-          <button type="button" className={cx('ion-calendar im-btn', {'is-active': tab === 0})} onClick={this.handleClickTab.bind(null, 0)}>
+          <button type="button" className={cx('ion-calendar im-btn', {'is-active': tab === 'date'})} onClick={this.handleClickTab.bind(null, 'date')}>
             Date
           </button>
-          <button type="button" className={cx('ion-clock im-btn', {'is-active': tab === 1})} onClick={this.handleClickTab.bind(null, 1)}>
+          <button type="button" className={cx('ion-clock im-btn', {'is-active': tab === 'time'})} onClick={this.handleClickTab.bind(null, 'time')}>
             Time
           </button>
         </div>
 
         <div className="tabs">
           <Calendar
-            className={cx('tab', {'is-active': tab === 0})}
+            className={cx('tab', {'is-active': tab === 'date'})}
             moment={m}
             onChange={this.props.onChange}
             prevMonthIcon={this.props.prevMonthIcon}
             nextMonthIcon={this.props.nextMonthIcon}
           />
           <Time
-            className={cx('tab', {'is-active': tab === 1})}
+            className={cx('tab', {'is-active': tab === 'time'})}
             moment={m}
             onChange={this.props.onChange}
           />


### PR DESCRIPTION
This change allows setting which view should be show initially.

The two options are `date` and `time` with the default as `date`.

``` javascript
<InputMoment
  initialTab="time"
  {...options}
/>
```

Technically you can pass in an invalid option which will result in neither tab being visible.  This could be considered a bug or a feature. 

Bug:  `<InputMoment initialTab="monkey" {...options} />`
Feature:  `<InputMoment initialTab="closed" {...options} />`
