### PR TITLE
Add isValid callback prop to allow locking dates

### DIFF
--- a/__tests__/__snapshots__/input-moment.js.snap
+++ b/__tests__/__snapshots__/input-moment.js.snap
@@ -84,43 +84,43 @@ exports[`render 1`] = `
         <tbody>
           <tr>
             <td
-              className="prev-month"
+              className="prev-month valid"
               onClick={[Function]}
             >
               29
             </td>
             <td
-              className="prev-month"
+              className="prev-month valid"
               onClick={[Function]}
             >
               30
             </td>
             <td
-              className="prev-month"
+              className="prev-month valid"
               onClick={[Function]}
             >
               31
             </td>
             <td
-              className=""
+              className="valid"
               onClick={[Function]}
             >
               1
             </td>
             <td
-              className=""
+              className="valid"
               onClick={[Function]}
             >
               2
             </td>
             <td
-              className=""
+              className="valid"
               onClick={[Function]}
             >
               3
             </td>
             <td
-              className=""
+              className="valid"
               onClick={[Function]}
             >
               4
@@ -128,43 +128,43 @@ exports[`render 1`] = `
           </tr>
           <tr>
             <td
-              className=""
+              className="valid"
               onClick={[Function]}
             >
               5
             </td>
             <td
-              className=""
+              className="valid"
               onClick={[Function]}
             >
               6
             </td>
             <td
-              className=""
+              className="valid"
               onClick={[Function]}
             >
               7
             </td>
             <td
-              className="current-day"
+              className="current-day valid"
               onClick={[Function]}
             >
               8
             </td>
             <td
-              className=""
+              className="valid"
               onClick={[Function]}
             >
               9
             </td>
             <td
-              className=""
+              className="valid"
               onClick={[Function]}
             >
               10
             </td>
             <td
-              className=""
+              className="valid"
               onClick={[Function]}
             >
               11
@@ -172,43 +172,43 @@ exports[`render 1`] = `
           </tr>
           <tr>
             <td
-              className=""
+              className="valid"
               onClick={[Function]}
             >
               12
             </td>
             <td
-              className=""
+              className="valid"
               onClick={[Function]}
             >
               13
             </td>
             <td
-              className=""
+              className="valid"
               onClick={[Function]}
             >
               14
             </td>
             <td
-              className=""
+              className="valid"
               onClick={[Function]}
             >
               15
             </td>
             <td
-              className=""
+              className="valid"
               onClick={[Function]}
             >
               16
             </td>
             <td
-              className=""
+              className="valid"
               onClick={[Function]}
             >
               17
             </td>
             <td
-              className=""
+              className="valid"
               onClick={[Function]}
             >
               18
@@ -216,43 +216,43 @@ exports[`render 1`] = `
           </tr>
           <tr>
             <td
-              className=""
+              className="valid"
               onClick={[Function]}
             >
               19
             </td>
             <td
-              className=""
+              className="valid"
               onClick={[Function]}
             >
               20
             </td>
             <td
-              className=""
+              className="valid"
               onClick={[Function]}
             >
               21
             </td>
             <td
-              className=""
+              className="valid"
               onClick={[Function]}
             >
               22
             </td>
             <td
-              className=""
+              className="valid"
               onClick={[Function]}
             >
               23
             </td>
             <td
-              className=""
+              className="valid"
               onClick={[Function]}
             >
               24
             </td>
             <td
-              className=""
+              className="valid"
               onClick={[Function]}
             >
               25
@@ -260,43 +260,43 @@ exports[`render 1`] = `
           </tr>
           <tr>
             <td
-              className=""
+              className="valid"
               onClick={[Function]}
             >
               26
             </td>
             <td
-              className=""
+              className="valid"
               onClick={[Function]}
             >
               27
             </td>
             <td
-              className=""
+              className="valid"
               onClick={[Function]}
             >
               28
             </td>
             <td
-              className=""
+              className="valid"
               onClick={[Function]}
             >
               29
             </td>
             <td
-              className=""
+              className="valid"
               onClick={[Function]}
             >
               30
             </td>
             <td
-              className=""
+              className="valid"
               onClick={[Function]}
             >
               31
             </td>
             <td
-              className="next-month"
+              className="next-month valid"
               onClick={[Function]}
             >
               1
@@ -304,43 +304,43 @@ exports[`render 1`] = `
           </tr>
           <tr>
             <td
-              className="next-month"
+              className="next-month valid"
               onClick={[Function]}
             >
               2
             </td>
             <td
-              className="next-month"
+              className="next-month valid"
               onClick={[Function]}
             >
               3
             </td>
             <td
-              className="next-month"
+              className="next-month valid"
               onClick={[Function]}
             >
               4
             </td>
             <td
-              className="next-month"
+              className="next-month valid"
               onClick={[Function]}
             >
               5
             </td>
             <td
-              className="next-month"
+              className="next-month valid"
               onClick={[Function]}
             >
               6
             </td>
             <td
-              className="next-month"
+              className="next-month valid"
               onClick={[Function]}
             >
               7
             </td>
             <td
-              className="next-month"
+              className="next-month valid"
               onClick={[Function]}
             >
               8

--- a/src/input-moment.js
+++ b/src/input-moment.js
@@ -9,7 +9,8 @@ export default class InputMoment extends Component {
     prevMonthIcon: 'ion-ios-arrow-left',
     nextMonthIcon: 'ion-ios-arrow-right',
     minStep: 1,
-    hourStep: 1
+    hourStep: 1,
+    isValid: () => true
   };
 
   state = {
@@ -36,6 +37,7 @@ export default class InputMoment extends Component {
       minStep,
       hourStep,
       onSave,
+      isValid,
       ...props
     } = this.props;
     const cls = cx('m-input-moment', className);
@@ -66,6 +68,7 @@ export default class InputMoment extends Component {
             onChange={this.props.onChange}
             prevMonthIcon={this.props.prevMonthIcon}
             nextMonthIcon={this.props.nextMonthIcon}
+            isValid={isValid}
           />
           <Time
             className={cx('tab', { 'is-active': tab === 1 })}

--- a/src/less/calendar.less
+++ b/src/less/calendar.less
@@ -31,7 +31,7 @@
   tbody td {
     color: #666666;
 
-    &:hover {
+    &.valid:hover {
       background: @color-blue;
       border-color: @color-blue;
       color: @color-white;
@@ -46,6 +46,13 @@
   .prev-month,
   .next-month {
     color: #999999;
+  }
+
+  .invalid {
+    color: @color-gray;
+    &:hover {
+      cursor: not-allowed;
+    }
   }
 
   .toolbar {


### PR DESCRIPTION
I have added an isValid callback which enables you to lock certain dates. This should be part of what issue #2 is asking.

I have had to change the standard behaviour slightly so that changing the month in the calendar view doesn't automatically update the date selected by the component until you actually click on a new date. This is to avoid a locked date becoming selected when the month is changed and allow you to navigate through an entirely locked month.

The isValid callback should look something like this:

``` javascript
function isValid(m) {
  // Disable weekends
  return m.day() != 0 && m.day() != 6;
}
```
