### PR TITLE
Support for minimum and maximum dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ http://wangzuo.github.io/input-moment
   hourStep={1} // default
   prevMonthIcon="ion-ios-arrow-left" // default
   nextMonthIcon="ion-ios-arrow-right" // default
+  minDate={this.state.minDate} // optional
+  maxDate={this.state.maxDate} // optional
 />
 ```
 Check [app.js](https://github.com/wangzuo/input-moment/blob/master/example/app.js) for a working example.

--- a/__tests__/__snapshots__/input-moment.js.snap
+++ b/__tests__/__snapshots__/input-moment.js.snap
@@ -33,6 +33,7 @@ exports[`render 1`] = `
       >
         <button
           className="prev-month"
+          disabled={false}
           onClick={[Function]}
           type="button"
         >
@@ -47,6 +48,7 @@ exports[`render 1`] = `
         </span>
         <button
           className="next-month"
+          disabled={false}
           onClick={[Function]}
           type="button"
         >

--- a/example/app.js
+++ b/example/app.js
@@ -20,15 +20,6 @@ class App extends Component {
   };
 
   render() {
-    const maxDate = moment();
-    const minDate = moment();
-    maxDate.set('month', moment().month() + 1);
-    maxDate.date(23);
-    minDate.date(11);
-
-    console.log('maxDate from app.js', maxDate);
-    console.log('minDate from app.js', minDate);
-
     return (
       <div className="app">
         <h1>
@@ -44,8 +35,6 @@ class App extends Component {
             onChange={this.handleChange}
             minStep={5}
             onSave={this.handleSave}
-            minDate={minDate}
-            maxDate={maxDate}
           />
         </form>
       </div>

--- a/example/app.js
+++ b/example/app.js
@@ -20,6 +20,9 @@ class App extends Component {
   };
 
   render() {
+    const maxDate = moment();
+    maxDate.set('month', moment().month() + 1);
+
     return (
       <div className="app">
         <h1>
@@ -35,6 +38,8 @@ class App extends Component {
             onChange={this.handleChange}
             minStep={5}
             onSave={this.handleSave}
+            minDate={moment()}
+            maxDate={maxDate}
           />
         </form>
       </div>

--- a/example/app.js
+++ b/example/app.js
@@ -8,7 +8,9 @@ import packageJson from '../package.json';
 
 class App extends Component {
   state = {
-    m: moment()
+    m: moment(),
+    minDate: moment(),
+    maxDate: moment().add(1, 'month')
   };
 
   handleChange = m => {
@@ -35,6 +37,8 @@ class App extends Component {
             onChange={this.handleChange}
             minStep={5}
             onSave={this.handleSave}
+            minDate={this.state.minDate}
+            maxDate={this.state.maxDate}
           />
         </form>
       </div>

--- a/example/app.js
+++ b/example/app.js
@@ -21,7 +21,13 @@ class App extends Component {
 
   render() {
     const maxDate = moment();
+    const minDate = moment();
     maxDate.set('month', moment().month() + 1);
+    maxDate.date(23);
+    minDate.date(11);
+
+    console.log('maxDate from app.js', maxDate);
+    console.log('minDate from app.js', minDate);
 
     return (
       <div className="app">
@@ -38,7 +44,7 @@ class App extends Component {
             onChange={this.handleChange}
             minStep={5}
             onSave={this.handleSave}
-            minDate={moment()}
+            minDate={minDate}
             maxDate={maxDate}
           />
         </form>

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -25,7 +25,7 @@ const Day = ({ i, w, d, minDate, maxDate, currentMoment, className, ...props }) 
     'prev-month': prevMonth,
     'next-month': nextMonth,
     'current-day': !prevMonth && !nextMonth && i === d,
-    'disabled-day': isDisabledDay(currentMomentCopy, minDate, maxDate)
+    'disabled-day': minDate && maxDate ? isDisabledDay(currentMomentCopy, minDate, maxDate) : false
   });
 
   if (isDisabledDay(currentMomentCopy, minDate, maxDate)) {

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -4,19 +4,22 @@ import cx from 'classnames';
 import range from 'lodash/range';
 import chunk from 'lodash/chunk';
 
-const isDisabledDay = (currentMoment, minDate, maxDate) => !currentMoment.isBetween(minDate, maxDate, null, '[]'); // '[]' indicates inclusion of both values.
+const isDisabledDay = (currentMoment, minDate, maxDate) => !currentMoment.isBetween(minDate, maxDate);
 
 const Day = ({ i, w, d, minDate, maxDate, currentMoment, className, ...props }) => {
   const prevMonth = w === 0 && i > 7;
   const nextMonth = w >= 4 && i <= 14;
   const currentMomentCopy = moment(currentMoment); // Moment clone.
-  currentMomentCopy.date(i);
 
   if (prevMonth) {
     currentMomentCopy.subtract(1, 'month');
-  } else if (nextMonth) {
+  }
+
+  if (nextMonth) {
     currentMomentCopy.add(1, 'month');
   }
+
+  currentMomentCopy.date(i); 
 
   const cls = cx({
     'prev-month': prevMonth,

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -4,7 +4,7 @@ import cx from 'classnames';
 import range from 'lodash/range';
 import chunk from 'lodash/chunk';
 
-const isDisabledDay = (currentMoment, minDate, maxDate) => !currentMoment.isBetween(minDate, maxDate);
+const isDisabledDay = (currentMoment, minDate, maxDate) => currentMoment.isBefore(minDate, 'day') || currentMoment.isAfter(maxDate, 'day');
 
 const Day = ({ i, w, d, minDate, maxDate, currentMoment, className, ...props }) => {
   const prevMonth = w === 0 && i > 7;
@@ -25,7 +25,7 @@ const Day = ({ i, w, d, minDate, maxDate, currentMoment, className, ...props }) 
     'prev-month': prevMonth,
     'next-month': nextMonth,
     'current-day': !prevMonth && !nextMonth && i === d,
-    'disabled-day': minDate && maxDate ? isDisabledDay(currentMomentCopy, minDate, maxDate) : false
+    'disabled-day': minDate || maxDate ? isDisabledDay(currentMomentCopy, minDate, maxDate) : false
   });
 
   if (isDisabledDay(currentMomentCopy, minDate, maxDate)) {

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -73,18 +73,32 @@ export default class Calendar extends Component {
 
   prevMonth = e => {
     e.preventDefault();
-    const minDate = this.props.minDate;
+    const momentCopy = this.props.moment;
+    const { minDate, maxDate } = this.props;
 
-    this.props.onChange(this.props.moment.subtract(1, 'month'));
+    momentCopy.subtract(1, 'month');
+
+    if (momentCopy.isBefore(minDate)) {
+      momentCopy.endOf('month');
+    }
+
+    this.props.onChange(momentCopy);          
     this.previousMonthShouldBeDisabled(this.state.currentTime);
     this.nextMonthShouldBeDisabled(this.state.currentTime);
   };
 
   nextMonth = e => {
     e.preventDefault();
-    const maxDate = this.props.maxDate;
+    const momentCopy = this.props.moment;
+    const { minDate, maxDate } = this.props;
 
-    this.props.onChange(this.props.moment.add(1, 'month'));
+    momentCopy.add(1, 'month');
+
+    if (momentCopy.isAfter(maxDate)) {
+      momentCopy.startOf('month');
+    }
+
+    this.props.onChange(momentCopy);
     this.previousMonthShouldBeDisabled(this.state.currentTime);
     this.nextMonthShouldBeDisabled(this.state.currentTime);
   };

--- a/src/input-moment.js
+++ b/src/input-moment.js
@@ -9,7 +9,9 @@ export default class InputMoment extends Component {
     prevMonthIcon: 'ion-ios-arrow-left',
     nextMonthIcon: 'ion-ios-arrow-right',
     minStep: 1,
-    hourStep: 1
+    hourStep: 1,
+    minDate: null,
+    maxDate: null
   };
 
   state = {
@@ -36,6 +38,8 @@ export default class InputMoment extends Component {
       minStep,
       hourStep,
       onSave,
+      minDate, 
+      maxDate,
       ...props
     } = this.props;
     const cls = cx('m-input-moment', className);
@@ -66,6 +70,8 @@ export default class InputMoment extends Component {
             onChange={this.props.onChange}
             prevMonthIcon={this.props.prevMonthIcon}
             nextMonthIcon={this.props.nextMonthIcon}
+            minDate={this.props.minDate}
+            maxDate={this.props.maxDate}
           />
           <Time
             className={cx('tab', { 'is-active': tab === 1 })}

--- a/src/less/calendar.less
+++ b/src/less/calendar.less
@@ -43,15 +43,6 @@
     font-weight: bold;
   }
 
-  .prev-month,
-  .next-month {
-    color: @color-gray-60;
-
-    &-disabled {
-      opacity: .4;
-    }
-  }
-
   .disabled-day {
     background-color: @color-gray;
     color: @color-gray-40;
@@ -70,6 +61,15 @@
       background-color: @color-gray;
       border-color: @color-gray;
       color: @color-gray-40;
+    }
+  }
+
+  .prev-month,
+  .next-month {
+    color: @color-gray-60;
+
+    &-disabled {
+      opacity: .4;
     }
   }
 

--- a/src/less/calendar.less
+++ b/src/less/calendar.less
@@ -43,17 +43,33 @@
     font-weight: bold;
   }
 
-  .disabled-day {
-    opacity: .4;
-    text-decoration: line-through;
-  }
-
   .prev-month,
   .next-month {
     color: #999999;
 
     &-disabled {
       opacity: .4;
+    }
+  }
+
+  .disabled-day {
+    background-color: black;
+    color: white;
+    cursor: not-allowed;
+    opacity: .4;
+
+    &.current-day {
+      color: @color-blue;
+
+      &:hover {
+        color: @color-blue;
+      }
+    }
+
+    &:hover {
+      background-color: black;
+      border-color: @color-gray;
+      color: white;
     }
   }
 

--- a/src/less/calendar.less
+++ b/src/less/calendar.less
@@ -29,7 +29,7 @@
   }
 
   tbody td {
-    color: #666666;
+    color: @color-gray-40;
 
     &:hover {
       background: @color-blue;
@@ -45,7 +45,7 @@
 
   .prev-month,
   .next-month {
-    color: #999999;
+    color: @color-gray-60;
 
     &-disabled {
       opacity: .4;
@@ -53,8 +53,8 @@
   }
 
   .disabled-day {
-    background-color: black;
-    color: white;
+    background-color: @color-gray;
+    color: @color-gray-40;
     cursor: not-allowed;
     opacity: .4;
 
@@ -67,9 +67,9 @@
     }
 
     &:hover {
-      background-color: black;
+      background-color: @color-gray;
       border-color: @color-gray;
-      color: white;
+      color: @color-gray-40;
     }
   }
 

--- a/src/less/calendar.less
+++ b/src/less/calendar.less
@@ -43,9 +43,18 @@
     font-weight: bold;
   }
 
+  .disabled-day {
+    opacity: .4;
+    text-decoration: line-through;
+  }
+
   .prev-month,
   .next-month {
     color: #999999;
+
+    &-disabled {
+      opacity: .4;
+    }
   }
 
   .toolbar {
@@ -69,6 +78,10 @@
       outline: 0;
       z-index: 5;
       cursor: pointer;
+
+      &:disabled {
+        cursor: not-allowed;
+      }
     }
 
     .prev-month {

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -1,5 +1,7 @@
 @color-blue: #1385e5;
 @color-gray: #dfe0e4;
+@color-gray-60: #999999;
+@color-gray-40: #666666;
 @color-white: #ffffff;
 @slider-handle-size: 20px;
 @slider-size: 4px;


### PR DESCRIPTION
## What's new on this PR?

- New optional prop `minDate` for `InputMoment` component.
- New optional prop `maxDate` for `InputMoment` component.
- Next & previous month buttons disabled depending on `minDate` and `maxDate`.
- Previous & after dates disabled depending on `minDate` and `maxDate`.
- `CSS` updates in order to apply `disabled` styles. 
- `Gray` color range updated at `variables.less` with two previously used gray colors.
- Example updated using both `minDate` and `maxDate` props.
- `README.md` updated with example using `minDate` & `maxDate`.
- `render` snapshot test updated in order to make it work with the new changes.

## Screenshots

**Previous month button disabled + previous dates disabled + after dates disabled**

<img width="364" alt="screen shot 2017-11-03 at 18 09 07" src="https://user-images.githubusercontent.com/19661411/32386662-41d3ac72-c0c2-11e7-8e0b-3d0d6c72f5a7.png">

**Next month button disabled + after dates disabled**

<img width="364" alt="screen shot 2017-11-03 at 18 09 43" src="https://user-images.githubusercontent.com/19661411/32386669-45b57ece-c0c2-11e7-8609-301a9792a2c5.png">

## How to test?

- Using the updated example (feel free to change the `minDate` and `maxDate` moments) play with the `input` trying to:
  - Click on previous & after dates (nothing should happen).
  - Click on previous & next month buttons (nothing should happen if disabled, same behaviour if enable).
  - Click on valid days (previous behaviour should be the same).
  - Whatever you would think in order to break & improve it.

## Related issue

[min and max dates](https://github.com/wangzuo/input-moment/issues/59)